### PR TITLE
Update to 7.6.8

### DIFF
--- a/libatomic_ops.cygport
+++ b/libatomic_ops.cygport
@@ -1,5 +1,5 @@
 NAME="libatomic_ops"
-VERSION=7.6.6
+VERSION=7.6.8
 RELEASE=1
 CATEGORY="Libs"
 SUMMARY="Atomic memory update operation library"


### PR DESCRIPTION
* Eliminate 'casting signed to bigger unsigned int' CSA warning (test_stack)
* Eliminate 'redundant blank line at start/end of block' CodeFactor warning
* Undefine AO_ARM_HAVE_* private macros after their usage
* Use standalone private macro to guard against AO_GCC_BARRIER redefinition
* Workaround 'condition my_chunk_ptr is always false' cppcheck false positive